### PR TITLE
update jupyter server entrypoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,11 @@ Run the following commands in a shell:
 pip install jupyter_http_over_ws
 # Optional: Install the extension to run every time the notebook server starts.
 # Adds a /http_over_websocket endpoint to the Tornado notebook server.
+
+# For jupyter server (JupyterLab)
+jupyter server extension enable --py jupyter_http_over_ws
+
+# For jupyter notebook
 jupyter serverextension enable --py jupyter_http_over_ws
 ```
 
@@ -23,6 +28,12 @@ explicitly trust WebSocket connections from the host communicating via
 HTTP-over-WebSocket.
 
 ```shell
+# jupyter server
+jupyter server \
+  --ServerApp.allow_origin='https://www.example.com' \
+  --port=8081
+
+# jupyter notebook
 jupyter notebook \
   --NotebookApp.allow_origin='https://www.example.com' \
   --port=8081
@@ -43,6 +54,13 @@ server using the `--no-browser` flag and open the provided link that appears in
 the terminal from the same browser that you would like to connect from:
 
 ```shell
+# jupyter server
+jupyter server \
+  --ServerApp.allow_origin='https://www.example.com' \
+  --port=8081
+  --no-browser
+
+# jupyter notebook
 jupyter notebook \
   --NotebookApp.allow_origin='https://www.example.com' \
   --port=8081
@@ -58,7 +76,12 @@ The jupyter server extension can be disabled and removed by running the
 following commands in a shell:
 
 ```shell
+# jupyter server
+jupyter server extension disable --py jupyter_http_over_ws
+
+# jupyter notebook
 jupyter serverextension disable --py jupyter_http_over_ws
+
 pip uninstall jupyter_http_over_ws
 ```
 

--- a/jupyter_http_over_ws/__init__.py
+++ b/jupyter_http_over_ws/__init__.py
@@ -16,7 +16,11 @@
 from jupyter_http_over_ws import handlers
 from notebook import utils
 
-__all__ = ['load_jupyter_server_extension', 'handlers']
+__all__ = [
+    '_load_jupyter_server_extension',
+    'load_jupyter_server_extension',
+    'handlers',
+]
 
 __version__ = str(handlers.HANDLER_VERSION)
 
@@ -32,7 +36,7 @@ def _handler_rule(app, handler_class):
                               handler_class.PATH), handler_class)
 
 
-def load_jupyter_server_extension(nb_server_app):
+def _load_jupyter_server_extension(nb_server_app):
   """Called by Jupyter when this module is loaded as a server extension."""
   app = nb_server_app.web_app
   host_pattern = '.*$'
@@ -44,3 +48,6 @@ def load_jupyter_server_extension(nb_server_app):
   ])
   print('jupyter_http_over_ws extension initialized. Listening on '
         '/http_over_websocket')
+
+
+load_jupyter_server_extension = _load_jupyter_server_extension


### PR DESCRIPTION
The entrypoint for jupyter server appears to have changed to be prefixed with an underscore, so this change updates the entrypoint, but leaves the existing name for legacy users. The documentation is also updated to show how to configure this extension if using `jupyter server` (JupyterLab).

See: https://jupyter-server.readthedocs.io/en/latest/developers/extensions.html#migrating-an-extension-to-use-jupyter-server